### PR TITLE
VLE/GKBE-12/optimize_cadd

### DIFF
--- a/app/back_end/src/routes/workspace_apply_route.py
+++ b/app/back_end/src/routes/workspace_apply_route.py
@@ -269,8 +269,8 @@ def get_workspace_apply_cadd(relative_path):
         os.makedirs(cadd_dir, exist_ok=True)
 
         try:
-            result_data_cadd = cadd_pipeline(pd.read_csv(apply_to,low_memory=False),
-                                             os.path.join(cadd_dir, "cadd.vcf"))
+            result_data_cadd = cadd_pipeline((pd.read_csv(apply_to,low_memory=False)).convert_dtypes(),
+                                             cadd_dir)
         except Exception as e:
             raise RuntimeError(f"Error applying CADD algorithm: {e}")
 
@@ -278,6 +278,7 @@ def get_workspace_apply_cadd(relative_path):
             result_data_cadd = pd.concat([existing_data, result_data_cadd], ignore_index=True)
 
         try:
+            result_data_cadd = result_data_cadd.convert_dtypes()
             result_data_cadd.to_csv(destination_path, index=False)
         except OSError as e:
             raise RuntimeError(f"Error saving file: {e}")

--- a/app/back_end/src/tools/cadd.py
+++ b/app/back_end/src/tools/cadd.py
@@ -1,36 +1,83 @@
 """ Module provides interface to web APIs of CADD tool. """
 import os
+import re
+import shutil
 import time
 import gzip
-import shutil
-import re
 from datetime import datetime
+from concurrent.futures import ProcessPoolExecutor
 
+import numpy as np
 import pandas as pd
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
-def gunzip_file(file_path:str):
+class CaddError(Exception):
+    """Custom exception for CADD-related errors."""
+    def __init__(self, message: str):
+        super().__init__(f"CADD Error: {message}")
+
+
+def create_cadd_input_files(chunk: pd.DataFrame, cadd_folder_path: str, chunk_id: int):
     """
-    Uncompresses a file from .gz format.
+    Generates a VCF (Variant Call Format) file from a dataframe chunk for CADD processing.
 
-    This function takes a file at the given file path and uncompresses it 
-    from a .gz file by reading the gzipped file and extracting it to a 
-    uncompressed version.
+    This function takes a portion of genomic data (`chunk`), writes it to a VCF file 
+    in the specified folder, and returns the file path along with the chunk ID.
 
     Args:
-        file_path (str): The path of the file to be uncompressed.
+        chunk (pd.DataFrame): A dataframe containing genomic variant data.
+        cadd_folder_path (str): Directory path where the VCF file should be saved.
+        chunk_id (int): Identifier for the data chunk, used in naming the output file.
 
     Returns:
-        str: The path to the newly gunzipped file.
+        tuple: A tuple containing:
+            - chunk_id (int): The identifier of the processed chunk.
+            - chunk_vcf_path (str): The full file path of the generated VCF file.
     """
-    with gzip.open(file_path, 'rb') as f_in:
-        with open(file_path[:-3], 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
+    chunk_vcf_path = os.path.join(cadd_folder_path,f"chunk_{chunk_id}.vcf")
+    write_vcf(dataframe=chunk, output_filepath=chunk_vcf_path)
+    return chunk_id, chunk_vcf_path
+
+
+def write_vcf(dataframe: pd.DataFrame, output_filepath: str) -> str:
+    """
+    Writes a VCF (Variant Call Format) file without header
+    from the given DataFrame, ensuring no duplicate variants.
+
+    This function extracts specific variant information
+    from a pandas DataFrame and writes it to a VCF file.
+    It ensures that duplicate variants (same chromosome, position, ref, and alt)
+    are not written multiple times.
+
+    Args:
+        dataframe (pd.DataFrame): The DataFrame containing the variant data.
+        output_filepath (str): The path where the VCF file will be saved.
+
+    Returns:
+        str: The file path where the VCF file has been written.
+    """
+    seen_variants = set()
+    with open(output_filepath, 'w', encoding='utf-8') as f:
+        variant_columns = ["hg38_gnomad_format", "variant_id_gnomad", "hg38_ID_clinvar"]
+        for row in dataframe.itertuples(index=False):
+            variant_value = next(
+            (getattr(row,col) for col in variant_columns
+            if hasattr(row,col) and pd.notna(getattr(row,col))
+            and getattr(row,col) != "?"), None
+            )
+            if variant_value:
+                parsed_variant = parse_variant(variant_value)
+                if parsed_variant:
+                    chrom, pos, ref, alt = parsed_variant
+                    if (chrom, pos, ref, alt) not in seen_variants:
+                        seen_variants.add((chrom, pos, ref, alt))
+                        f.write(f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t.\t.\t.\n")
+    return output_filepath
 
 
 def gzip_file(file_path: str):
@@ -48,24 +95,191 @@ def gzip_file(file_path: str):
         str: The path to the newly gzipped file.
     """
     gzipped_file_path = f"{file_path}.gz"
+    try:
+        with open(file_path, 'rb') as f_in:
+            with gzip.open(gzipped_file_path, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        return gzipped_file_path
+    except Exception as e:
+        raise CaddError(f"Error during compression of file {file_path}: {str(e)}") from e
 
-    with open(file_path, 'rb') as f_in:
-        with gzip.open(gzipped_file_path, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
 
-    return gzipped_file_path
+def send_cadd_input_files(gzipped_chunk_path:str,chunk_id:int):
+    """
+    Uploads a gzipped genomic data chunk to the CADD web service and retrieves the job URL.
+
+    This function automates the process of submitting a gzipped genomic variant file 
+    to the CADD (Combined Annotation Dependent Depletion) web service using a Firefox 
+    web driver. After submission, it waits for the job to complete and returns the URL 
+    for checking the job status.
+
+    Args:
+        gzipped_chunk_path (str): The file path of the gzipped input data chunk to be uploaded.
+        chunk_id (int): The identifier for the data chunk, used to track the submission.
+
+    Returns:
+        tuple: A tuple containing:
+            - chunk_id (int): The identifier of the processed chunk.
+            - job_url (str): The URL to check the status of the CADD job.
+    
+    Raises:
+        TimeoutException: If the status or availability link is not found within the given time.
+    """
+    options = webdriver.FirefoxOptions()
+    options.add_argument("--headless")
+    options.set_preference("browser.download.manager.showWhenStarting", False)
+    driver = webdriver.Firefox(options=options)
+    driver.get("https://cadd.bihealth.org/score")
+
+    file_input = WebDriverWait(driver, 20).until(
+        EC.presence_of_element_located((By.NAME, "file"))
+    )
+    file_input.send_keys(os.path.abspath(gzipped_chunk_path))
+
+    submit_button = driver.find_element(By.XPATH, '//input[@type="submit"]')
+    submit_button.click()
+
+    WebDriverWait(driver, 5).until(EC.url_contains("/upload"))
+    try:
+        finished_link = WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/static/finished/")]'))
+        )
+        job_file = extract_job_file(finished_link.get_attribute("href"))
+    except TimeoutException:
+        try:
+            check_avail_link = WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/check_avail/")]'))
+            )
+            job_file = extract_job_file(check_avail_link.get_attribute("href"))
+        except TimeoutException as exc:
+            raise CaddError(
+            f"Could not find the job status link (/check_avail/).Error:{str(exc)}") from exc
+    driver.quit()
+
+    return chunk_id, f"https://cadd.bihealth.org/check_avail/{job_file}"
 
 
-def parse_variant(variant_str):
+def extract_job_file(url:str):
+    """
+    Extracts the filename from a given URL.
+
+    This function retrieves the last segment of a URL (typically a filename).
+    It assumes the filename appears at the end of the URL, following the last '/'.
+
+    Args:
+        url (str): The URL string from which the filename will be extracted.
+
+    Returns:
+        str: The extracted filename.
+
+    Raises:
+       CaddError: If no valid filename is found in the URL.
+
+    Example:
+        >>> extract_job_id("
+        https://cadd.bihealth.org/check_avail/
+        GRCh38-v1.7_fdf994281314d8d098d2cd17ade6458a.tsv.gz")
+        'GRCh38-v1.7_fdf994281314d8d098d2cd17ade6458a.tsv.gz'
+    """
+    match = re.search(r'/([^/]+)$', url)
+    if match:
+        return match.group(1)
+    raise CaddError("CADD server: Invalid URL format - filename not found.")
+
+
+def get_cadd_output_files(cadd_job_url: str, cadd_output_dir: str, chunk_id: int,max_retries=3):
+    """Downloads CADD output file while preventing infinite loops.
+    
+    Args:
+        cadd_job_url (str): The URL of the CADD job.
+        cadd_output_dir (str): The directory to save the output file.
+        chunk_id (int): The chunk identifier.
+        max_retries (int): Maximum number of retries before giving up.
+        retry_interval (int): Time (in seconds) between retries.
+    
+    Returns:
+        tuple: (chunk_id, job_id) if successful, else raises TimeoutException.
+    """
+    options = webdriver.FirefoxOptions()
+    options.add_argument("--headless")
+    options.set_preference("browser.download.folderList", 2)
+    options.set_preference("browser.download.manager.showWhenStarting", False)
+    options.set_preference("browser.download.dir", cadd_output_dir)
+    options.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/gzip")
+
+    driver = webdriver.Firefox(options=options)
+    retry_count = 0
+
+    driver.get(cadd_job_url)
+    try:
+        finished_link = WebDriverWait(driver, 3).until(
+            EC.presence_of_element_located(
+            (By.XPATH, '//a[contains(@href, "/static/finished/")]')))
+        job_file = extract_job_file(finished_link.get_attribute("href"))
+        finished_link.click()
+    except TimeoutException:
+        for retry_count in range(max_retries):
+            driver.refresh()
+            try:
+                finished_link = WebDriverWait(driver, 3).until(
+                    EC.presence_of_element_located(
+                        (By.XPATH, '//a[contains(@href, "/static/finished/")]'))
+                )
+                job_file = extract_job_file(finished_link.get_attribute("href"))
+                finished_link.click()
+                break
+            except TimeoutException as e:
+                if retry_count == max_retries - 1:
+                    error_message = (
+                        f"Max retries reached: Unable to fetch CADD output from {cadd_job_url} "
+                        f"after {max_retries} attempts."
+                    )
+                    raise CaddError(error_message) from e
+                time.sleep(60)
+    driver.quit()
+    return chunk_id, job_file
+
+
+def gunzip_file(file_path: str, chunk_id: int):
+    """
+    Uncompresses a .gz file to its uncompressed version.
+
+    This function takes a gzipped file at the given file path and uncompresses it 
+    by reading the .gz file and extracting it to an uncompressed version.
+
+    Args:
+        file_path (str): The path of the gzipped file to be uncompressed.
+        chunk_id (int): The chunk identifier associated with the file.
+
+    Returns:
+        tuple: A tuple containing the chunk_id and the path to the uncompressed file.
+    
+    Raises:
+        CaddError: If an error occurs during the decompression process.
+    """
+    uncompressed_file_path = file_path[:-3]
+    try:
+        with gzip.open(file_path, 'rb') as f_in:
+            with open(uncompressed_file_path, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        return chunk_id, uncompressed_file_path
+    except Exception as e:
+        raise CaddError(f"Error during decompression of file {file_path}: {str(e)}") from e
+
+
+def parse_variant(variant_str:str):
     """
     Parses a variant string and extracts chromosome, position, reference, and alternative alleles.
 
-    The function takes a variant string in the format of `chrom-pos-ref-alt` (e.g., `1-123-A-G`), 
-    and splits it into the individual components. If the string contains only chromosome and position 
-    (e.g., `1-123`), it will assume reference and alternative alleles as missing (represented by `"."`).
+    The function takes a variant string in the format of `chrom-pos-ref-alt` (e.g., `1-123-A-G`),
+    and splits it into the individual components. 
+    If the string contains only chromosome and position
+    (e.g., `1-123`), it will assume reference and 
+    alternative alleles as missing (represented by `"."`).
 
     Args:
-        variant_str (str): The variant string to be parsed, typically in the format `chrom-pos-ref-alt`.
+        variant_str (str): The variant string to be parsed,
+        typically in the format `chrom-pos-ref-alt`.
 
     Returns:
         tuple: A tuple containing:
@@ -76,268 +290,161 @@ def parse_variant(variant_str):
 
     Example:
         parse_variant("1-123-A-G")  -> ('1', '123', 'A', 'G')
-        parse_variant("1-123")      -> ('1', '123', '.', '.')
     """
     try:
+        if not isinstance(variant_str, str):
+            return None
         chrom, pos, ref, alt = variant_str.split("-")
+        if not chrom or not pos or not ref or not alt:
+            return None
         return chrom, pos, ref, alt
-    except ValueError:
-        chrom, pos, _ = variant_str.split("-")
-        return chrom, pos, ".", "."
-    except AttributeError:
-        return ".", ".", ".", "."
-    
+    except (ValueError, AttributeError):
+        return None
 
-def extract_job_id(url:str):
+
+def parse_tsv(file_path:str)->pd.DataFrame:
     """
-    Extracts the job ID from a given URL.
+    Parses a TSV file and returns a DataFrame with two columns: 'cadd_gen_position' and 'PHRED'.
 
-    This function searches for a 32-character hexadecimal string (typically used as a job ID)
-    in the provided URL. 
-    The job ID is expected to be in the format `_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
-    where `x` is a hexadecimal character (a-f, 0-9).
+    The function reads the TSV file, skipping comment lines, and generates a new column, 
+    'cadd_gen_position', by concatenating 'Chrom', 'Pos', 'Ref', and 'Alt'. It also extracts 
+    the 'PHRED' scores.
 
     Args:
-        url (str): The URL string from which the job ID will be extracted.
+        file_path (str): Path to the TSV file.
 
     Returns:
-        str or None: The extracted job ID as a string (without the leading underscore), 
-        or None if no valid job ID is found.
+        pd.DataFrame: DataFrame with 'cadd_gen_position' and 'PHRED' columns.
 
+    Example:
+        result = parse_tsv('file_path.tsv')
     """
-    match = re.search(r'_([a-f0-9]{32})', url)
-    if match:
-        return match.group(0)
+    df = pd.read_csv(file_path, sep='\t', comment='#',
+                    names=['Chrom', 'Pos', 'Ref', 'Alt', 'RawScore', 'PHRED'])
+    df['cadd_gen_position'] = (
+    df['Chrom'].astype(str) + '-' +
+    df['Pos'].astype(str) + '-' +
+    df['Ref'] + '-' +
+    df['Alt'])
+    return df[['cadd_gen_position', 'PHRED']]
+
+
+def create_position(row):
+    """
+    Extracts the first non-null, non-empty genomic position identifier from the given row.
+
+    This function checks specific columns in the input row (`hg38_gnomad_format`, 
+    `variant_id_gnomad`, and `hg38_ID_clinvar`) and returns the first encountered 
+    value that is not NaN and not an empty string. If all columns are empty or NaN, 
+    it returns None.
+
+    Args:
+        row (pd.Series): A Pandas Series representing a row of a DataFrame.
+
+    Returns:
+        str or None: The first valid position identifier found in the specified columns, 
+        or None if all are empty or NaN.
+    """
+    for col in ['hg38_gnomad_format', 'variant_id_gnomad', 'hg38_ID_clinvar']:
+        if pd.notna(row[col]) and row[col] != '':
+            return row[col]
     return None
 
 
-def get_cadd_scores_file(file_path:str):
+def merge_with_tsv(data_chunk:pd.DataFrame, tsv_chunk):
     """
-    Processes a given VCF file to retrieve CADD scores.
-
-    This function renames the input file with a timestamp, sets up a 
-    headless Firefox WebDriver with appropriate download preferences, 
-    and downloads CADD scores from an online source. The downloaded 
-    file is then extracted and cleaned up.
-
-    Args:
-        file_path (str): The path to the input VCF file.
-
-    Returns:
-        str: The path to the processed CADD scores TSV file.
-
-    Steps:
-        1. Rename the input file to include a timestamp.
-        2. Configure a headless Firefox WebDriver for automated download.
-        3. Download CADD scores using the provided VCF file.
-        4. Extract the downloaded GZ file and remove the compressed version.
-        5. Return the path to the extracted CADD scores TSV file.
-    """
-   
-    download_dir = os.path.dirname(file_path)
-
-    options = webdriver.FirefoxOptions()
-    options.add_argument("--headless")
+    Merges the given data_chunk with the tsv_chunk DataFrame based on matching values
+    between the 'cadd_gen_position' column in tsv_chunk and the corresponding columns 
+    ('hg38_gnomad_format', 'variant_id_gnomad', 'hg38_ID_clinvar') in data_chunk.
     
-    if not os.path.exists(download_dir):
-        os.makedirs(download_dir)
-
-    options.set_preference("browser.download.folderList", 2)
-    options.set_preference("browser.download.manager.showWhenStarting", False)
-    options.set_preference("browser.download.dir", download_dir)
-    options.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/gzip")
-
-    driver = webdriver.Firefox(options=options)
-
-    job_id = download_cadd_scores(driver=driver,vcf_file_path=file_path)
-
-    downloaded_file = os.path.join(download_dir, f"GRCh38-v1.7{job_id}.tsv.gz")
-    gunzip_file(downloaded_file)
-    os.remove(downloaded_file)
-
-    return os.path.join(download_dir, f"GRCh38-v1.7{job_id}.tsv")
-
-
-def download_cadd_scores(driver:webdriver.Firefox,vcf_file_path:str):
-    """
-    Downloads CADD (Combined Annotation-Dependent Depletion) scores for a given VCF file.
-
-    This function automates the process of uploading a VCF file to the CADD web service, 
-    checking the job status, and downloading the resulting CADD scores file. It uses Selenium 
-    WebDriver to interact with the CADD website, waits for the job to finish, and retrieves 
-    the resulting file.
+    The function uses the first non-empty value from these 
+    columns to construct the 'cadd_gen_position' key.
+    If a matching CADD score is not found in tsv_chunk, 
+    the PHRED value will be set to "Cadd score unavailable".
 
     Args:
-        driver (webdriver.Firefox): The WebDriver instance to interact with the browser.
-        vcf_file_path (str): The local path to the VCF file to be uploaded to the CADD service.
+        data_chunk (pd.DataFrame): The DataFrame containing genomic data to be merged.
+        tsv_chunk (pd.DataFrame): The DataFrame containing CADD genomic positions.
 
     Returns:
-        str: job_id of processed file from CADD web-server.
-    
-    Raises:
-        TimeoutException: If the job status link or finished file link cannot be found within the 
-                          expected time frame.
+        pd.DataFrame: The merged DataFrame based on the matching positions.
     """
-    try:
-        driver.get("https://cadd.bihealth.org/score")
 
-        file_input = WebDriverWait(driver, 20).until(
-            EC.presence_of_element_located((By.NAME, "file"))
-        )
-        file_input.send_keys(os.path.abspath(vcf_file_path))
+    data_chunk['cadd_gen_position'] = data_chunk.apply(create_position, axis=1)
+    merged_df = pd.merge(data_chunk, tsv_chunk[['cadd_gen_position', 'PHRED']],
+                         on='cadd_gen_position', how='left')
+    merged_df['PHRED'] = merged_df['PHRED'].fillna('Cadd score unavailable')
+    merged_df.drop(columns=['cadd_gen_position'])
 
-        submit_button = driver.find_element(By.XPATH, '//input[@type="submit"]')
-        submit_button.click()
-
-        WebDriverWait(driver, 20).until(EC.url_contains("/upload"))
-
-        try:
-            finished_link = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/static/finished/")]'))
-            )
-            job_id = extract_job_id(finished_link.get_attribute("href"))
-            finished_link.click()
-            time.sleep(5)
-        except:
-            try:
-                check_avail_link = WebDriverWait(driver, 30).until(
-                    EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/check_avail/")]'))
-                )
-                job_url = check_avail_link.get_attribute("href")
-                job_id = extract_job_id(job_url)
-            except TimeoutException:
-                raise TimeoutException("CADD:Could not find the job status link (/check_avail/).")
-
-            driver.get(job_url)
-
-            while True:
-                driver.refresh()
-                try:
-                    finished_link = WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/static/finished/")]'))
-                    )
-                    job_id = extract_job_id(finished_link.get_attribute("href"))
-                    finished_link.click()
-                    time.sleep(5)
-                    break
-                except:
-                    time.sleep(60)
-    finally:
-        driver.quit()
-        return job_id
+    return merged_df
 
 
-def write_vcf(dataframe:pd.DataFrame, output_filepath:str) -> str:
+def cadd_pipeline(dataframe: pd.DataFrame, cadd_folder_path: str) -> pd.DataFrame:
     """
-    Writes a VCF (Variant Call Format) file without header
-    from the given DataFrame.
-
-    This function extracts specific variant information
-    from a pandas DataFrame and writes it to a VCF file.
-    For each row, the function extracts the first valid variant value 
-    found in these columns, parses it, and writes the corresponding VCF line.
+    Process genomic data through multiple stages of file creation, uploading, 
+    fetching results, parsing, and merging with CADD data. 
 
     Args:
-        dataframe (pd.DataFrame): The DataFrame containing the variant data.
-        output_filepath (str): The path where the VCF file will be saved.
+        dataframe (pd.DataFrame): The input genomic data.
+        cadd_folder_path (str): Path to store temporary input/output files for CADD processing.
 
     Returns:
-        str: The file path where the VCF file has been written.
+        pd.DataFrame: The final merged dataframe with CADD scores.
     """
-    with open(output_filepath, 'w') as f:
-        variant_columns = ["hg38_gnomad_format", "variant_id_gnomad","variant_id", "hg38_ID_clinvar"]
-        for _, row in dataframe.iterrows():
-            variant_value = None
-            for col in variant_columns:
-                if col in row and pd.notna(row[col]) and row[col]!="?":
-                    variant_value = row[col]
-                    break
-            chrom, pos, ref, alt = parse_variant(variant_value)
-            vcf_line = f"{chrom}\t{pos}\t.\t{ref}\t{alt}\n"
-            f.write(vcf_line) 
-    return output_filepath  
+    num_chunks = max(2, len(dataframe) // 1000)
+    data_chunks = np.array_split(dataframe, num_chunks)
+    vcf_gziped_chunks={}
+    cadd_job_chunks={}
+    tsv_chunks={}
+    merged_chunks={}
 
+    cadd_folder_path = os.path.join(cadd_folder_path,
+                                    datetime.now().strftime("%Y%m%d_%H%M%S"))
+    cadd_folder_input = os.path.join(cadd_folder_path,"input")
+    cadd_folder_output = os.path.join(cadd_folder_path,"output")
+    if not os.path.exists(cadd_folder_input):
+        os.makedirs(cadd_folder_input)
+    if not os.path.exists(cadd_folder_output):
+        os.makedirs(cadd_folder_output)
 
-def parse_tsv(tsv_file_path: str, vcf_file_path: str):
-    """
-    Parses a TSV (Tab-Separated Values) file to extract PHRED scores.
+    with ProcessPoolExecutor() as executor:
+        jobs = {executor.submit(
+            create_cadd_input_files,
+            data_chunks[i],
+            cadd_folder_input,
+            i): i for i in range(num_chunks)}
+        for job in jobs:
+            chunk_id, vcf_chunk_path = job.result()
+            vcf_gziped_chunks[chunk_id] = gzip_file(vcf_chunk_path)
+            os.remove(os.path.join(cadd_folder_input,vcf_chunk_path))
 
-    This function reads a TSV file, skips comment lines (lines starting with `#`),
-    and extracts PHRED scores from the sixth column (index 5) based on variant
-    positions and alleles found in the VCF file. If a corresponding value is not
-    found, "CADD score unavailable" is stored.
+    for i in range(num_chunks):
+        chunk_id, cadd_job_url = send_cadd_input_files(
+            vcf_gziped_chunks[i],
+            i)
+        os.remove(os.path.join(cadd_folder_input,vcf_gziped_chunks[chunk_id]))
+        cadd_job_chunks[chunk_id] = cadd_job_url
 
-    Args:
-        tsv_file_path (str): The path to the TSV file.
-        vcf_file_path (str): The path to the VCF file.
+    for i in range(num_chunks):
+        chunk_id, cadd_gzip_file_path = get_cadd_output_files(
+            cadd_job_chunks[i],
+            cadd_folder_output,
+            i)
+        renamed_path = os.path.join(cadd_folder_output,f"cadd_chunk_{chunk_id}.tsv.gz")
+        os.rename(os.path.join(cadd_folder_output,cadd_gzip_file_path),
+                  renamed_path)
+        tsv_chunks[chunk_id] = renamed_path
 
-    Returns:
-        dict: A dictionary mapping VCF variants (chrom, pos, ref, alt) to PHRED scores,
-              or "CADD score unavailable" if no match is found.
-
-    Raises:
-        ValueError: If an error occurs while reading or parsing the file.
-    """
-    try:
-        tsv_data = {}
-        with open(tsv_file_path, 'r', encoding='utf-8') as tsv:
-            for line in tsv:
-                if line.startswith('#'):
-                    continue
-                columns = line.strip().split('\t')
-                key = f"{columns[0]}:{columns[1]}:{columns[2]}:{columns[3]}"
-                tsv_data[key] = columns[5]
-
-        phred_scores = []
-        with open(vcf_file_path, 'r', encoding='utf-8') as vcf:
-            for line in vcf:
-                columns = line.strip().split('\t')
-                if len(columns) < 5:
-                    phred_scores.append("CADD score unavailable")
-                    continue
-                key = f"{columns[0]}:{columns[1]}:{columns[3]}:{columns[4]}"
-                phred_scores.append(tsv_data.get(key, "CADD score unavailable"))
-        
-        return phred_scores
-    
-    except Exception as e:
-        raise ValueError(f"CADD: Error parsing files {tsv_file_path} or {vcf_file_path}: {e}") from e
-
-
-def cadd_pipeline(dataframe:pd.DataFrame,vcf_file_path:str)->pd.DataFrame:
-    """
-    Executes the CADD (Combined Annotation Dependent Depletion) scoring pipeline.
-
-    This function processes a given dataframe by:
-    1. Writing it to a VCF file.
-    2. Compressing the VCF file.
-    3. Submitting it to the CADD server to retrieve PHRED-like scores.
-    4. Parsing the downloaded scores and appending them to the original dataframe.
-
-    Args:
-        dataframe (pd.DataFrame): The input dataframe containing variant data.
-        vcf_file_path (str): The file path where the VCF file will be stored.
-
-    Returns:
-        pd.DataFrame: The original dataframe with an additional column "PHRED_cadd"
-                      containing the CADD scores.
-
-    Steps:
-        1. Create a copy of the input dataframe.
-        2. Write the dataframe to a VCF file.
-        3. Compress the VCF file using gzip.
-        4. Retrieve CADD scores for the compressed VCF file.
-        5. Parse the downloaded scores and append them to the dataframe.
-        6. Remove the temporary CADD TSV file.
-        7. Return the dataframe with the appended CADD scores.
-    """
-    data_copy=dataframe.copy()
-    input_vcf_file=write_vcf(dataframe=data_copy,output_filepath=vcf_file_path)
-    gzipped_file_path = gzip_file(input_vcf_file)
-    cadd_tsv_file=get_cadd_scores_file(gzipped_file_path)
-    os.remove(gzipped_file_path)
-    scores = parse_tsv(tsv_file_path=cadd_tsv_file,vcf_file_path=input_vcf_file)
-    scores_df = pd.DataFrame(scores)
-    scores_df.columns = ["PHRED_cadd"]
-    data_copy = pd.concat([data_copy,scores_df], axis=1)
-    return data_copy
+    with ProcessPoolExecutor() as executor:
+        jobs = {executor.submit(
+            gunzip_file,
+            os.path.join(cadd_folder_output,
+            tsv_chunks[i]),
+            i): i for i in range(num_chunks)}
+        for job in jobs:
+            chunk_id, cadd_tsv_file_path = job.result()
+            merged_chunks[chunk_id] = merge_with_tsv(
+                data_chunks[chunk_id],
+                parse_tsv(cadd_tsv_file_path))
+            os.remove(os.path.join(cadd_folder_output,cadd_tsv_file_path))
+    return pd.concat(merged_chunks.values(), ignore_index=True)


### PR DESCRIPTION
# Initial (2025-03-18)
- [VLE/GKBE-12/optimize_cadd](https://github.com/kathteam/kath-v0.2-alpha/commit/5c831044b69ccfac5ffe4e4358499e5ba4afc974)

1. Takes DataFrame and divides it into several slices(minimum 2 slices - each slice 1000 rows)
2. Creates VCF files based on database slices
3. Gzips them
4. Sends all files to CADD German server and retrieves job_id_file
5. Waits for every file to process and downloads them
6. Gunzips all tsv output files from CADD server
7. Parses tsv files into DataFrames
8. Merges scores with original DataFrame

- **Only unique gen_pos-ref-alt variants are sent to CADD server - that's why size of some VCF files is not exactly 1000**
- **If CADD server did not give any score to variant - it got CADD_score_unavailable value for PHRED column**

